### PR TITLE
InstructorLogicTest - Refactor try-catch blocks to improve code quality #8162

### DIFF
--- a/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
@@ -122,32 +122,26 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("success: get an instructor by using email");
 
-        String courseId = "idOfTypicalCourse1";
-        String email = "instructor1@course1.tmt";
-
-        InstructorAttributes instr = instructorsLogic.getInstructorForEmail(courseId, email);
-
-        assertEquals(courseId, instr.courseId);
-        assertEquals(email, instr.email);
+        String[] courseId = {null, "idOfTypicalCourse1"};        
+        String[] email = {"instructor1@course1.tmt", null};
+              
+        InstructorAttributes instr = instructorsLogic.getInstructorForEmail(courseId[1], email[0]);
+        assertEquals(courseId[1], instr.courseId);
+        assertEquals(email[0], instr.email);
         assertEquals("idOfInstructor1OfCourse1", instr.googleId);
         assertEquals("Instructor1 Course1", instr.name);
-
+        
         ______TS("failure: null parameters");
-
-        try {
-            instructorsLogic.getInstructorForEmail(null, email);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+        
+        for (int i = 0; i < 2; i++) {
+           
+            try {
+                instructorsLogic.getInstructorForEmail(courseId[i], email[i]);
+                signalFailureToDetectException();
+            } catch (AssertionError e) {
+                AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+            }            
         }
-
-        try {
-            instructorsLogic.getInstructorForEmail(courseId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
-
     }
 
     private void testGetInstructorForGoogleId() {
@@ -158,32 +152,27 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("success: typical case");
 
-        String courseId = "idOfTypicalCourse1";
-        String googleId = "idOfInstructor1OfCourse1";
+        String[] courseId = {null, "idOfTypicalCourse1"}; 
+        String[] googleId = {"idOfInstructor1OfCourse1", null};
 
-        InstructorAttributes instr = instructorsLogic.getInstructorForGoogleId(courseId, googleId);
+        InstructorAttributes instr = instructorsLogic.getInstructorForGoogleId(courseId[1], googleId[0]);
 
-        assertEquals(courseId, instr.courseId);
-        assertEquals(googleId, instr.googleId);
+        assertEquals(courseId[1], instr.courseId);
+        assertEquals(googleId[0], instr.googleId);
         assertEquals("instructor1@course1.tmt", instr.email);
         assertEquals("Instructor1 Course1", instr.name);
 
         ______TS("failure: null parameters");
-
-        try {
-            instructorsLogic.getInstructorForGoogleId(null, googleId);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+        
+        for (int i = 0; i < 2; i++) {
+            
+            try {
+                instructorsLogic.getInstructorForGoogleId(courseId[i], googleId[i]);
+                signalFailureToDetectException();
+            } catch (AssertionError e) {
+                AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+            }
         }
-
-        try {
-            instructorsLogic.getInstructorForGoogleId(courseId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
-
     }
 
     private void testGetInstructorForRegistrationKey() {
@@ -322,10 +311,10 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("success: get encrypted key for instructor");
 
-        String courseId = "idOfSampleCourse-demo";
-        String email = "instructorNotYetJoined@email.tmt";
+        String[] courseId = {null, "idOfSampleCourse-demo"}; 
+        String[] email = {"instructorNotYetJoined@email.tmt", null, "non-existent@email.tmt"};
 
-        InstructorAttributes instructor = instructorsDb.getInstructorForEmail(courseId, email);
+        InstructorAttributes instructor = instructorsDb.getInstructorForEmail(courseId[1], email[0]);
 
         String key = instructorsLogic.getEncryptedKeyForInstructor(instructor.courseId, instructor.email);
         String expected = StringHelper.encrypt(instructor.key);
@@ -334,64 +323,53 @@ public class InstructorsLogicTest extends BaseLogicTest {
         ______TS("failure: non-existent instructor");
 
         try {
-            instructorsLogic.getEncryptedKeyForInstructor(courseId, "non-existent@email.tmt");
+            instructorsLogic.getEncryptedKeyForInstructor(courseId[1], email[2]);
             signalFailureToDetectException();
         } catch (EntityDoesNotExistException e) {
             assertEquals("Instructor " + "non-existent@email.tmt"
-                    + " does not belong to course " + courseId, e.getMessage());
+                    + " does not belong to course " + courseId[1], e.getMessage());
         }
 
         ______TS("failure: null parameter");
-
-        try {
-            instructorsLogic.getEncryptedKeyForInstructor(courseId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+        for (int i = 0; i < 2; i++) {
+            
+            try {
+                instructorsLogic.getEncryptedKeyForInstructor(courseId[i], email[i]);
+                signalFailureToDetectException();
+            } catch (AssertionError e) {
+                AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+            }
         }
-
-        try {
-            instructorsLogic.getEncryptedKeyForInstructor(null, email);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
-
     }
 
     private void testIsGoogleIdOfInstructorOfCourse() {
 
         ______TS("success: is an instructor of a given course");
 
-        String instructorId = "idOfInstructor1OfCourse1";
-        String courseId = "idOfTypicalCourse1";
+        String[] courseId = {null, "idOfTypicalCourse1"}; 
+        String[] instructorId = {"idOfInstructor1OfCourse1", null};
 
-        boolean result = instructorsLogic.isGoogleIdOfInstructorOfCourse(instructorId, courseId);
+        boolean result = instructorsLogic.isGoogleIdOfInstructorOfCourse(instructorId[0], courseId[1]);
 
         assertTrue(result);
 
         ______TS("failure: not an instructor of a given course");
 
-        courseId = "idOfTypicalCourse2";
+        courseId[1] = "idOfTypicalCourse2";
 
-        result = instructorsLogic.isGoogleIdOfInstructorOfCourse(instructorId, courseId);
+        result = instructorsLogic.isGoogleIdOfInstructorOfCourse(instructorId[0], courseId[1]);
 
         assertFalse(result);
 
         ______TS("failure: null parameter");
-
-        try {
-            instructorsLogic.isGoogleIdOfInstructorOfCourse(null, courseId);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
-
-        try {
-            instructorsLogic.isGoogleIdOfInstructorOfCourse(instructorId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+        for (int i = 0; i < 2; i++) {
+            
+            try {
+                instructorsLogic.isGoogleIdOfInstructorOfCourse(instructorId[i], courseId[i]);
+                signalFailureToDetectException();
+            } catch (AssertionError e) {
+                AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+            }
         }
     }
 
@@ -399,37 +377,32 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("success: is an instructor of a given course");
 
-        String instructorEmail = "instructor1@course1.tmt";
-        String courseId = "idOfTypicalCourse1";
+        String[] instructorEmail = {"instructor1@course1.tmt", null};
+        String[] courseId = {null, "idOfTypicalCourse1"};
 
-        boolean result = instructorsLogic.isEmailOfInstructorOfCourse(instructorEmail, courseId);
+        boolean result = instructorsLogic.isEmailOfInstructorOfCourse(instructorEmail[0], courseId[1]);
 
         assertTrue(result);
 
         ______TS("failure: not an instructor of a given course");
 
-        courseId = "idOfTypicalCourse2";
+        courseId[1] = "idOfTypicalCourse2";
 
-        result = instructorsLogic.isEmailOfInstructorOfCourse(instructorEmail, courseId);
+        result = instructorsLogic.isEmailOfInstructorOfCourse(instructorEmail[0], courseId[1]);
 
         assertFalse(result);
 
         ______TS("failure: null parameter");
-
-        try {
-            instructorsLogic.isEmailOfInstructorOfCourse(instructorEmail, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+        
+        for (int i = 0; i < 2; i++) {
+            
+            try {
+                instructorsLogic.isEmailOfInstructorOfCourse(instructorEmail[i], courseId[i]);
+                signalFailureToDetectException();
+            } catch (AssertionError e) {
+                AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+            }
         }
-
-        try {
-            instructorsLogic.isEmailOfInstructorOfCourse(null, courseId);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
-
     }
 
     private void testVerifyInstructorExists() throws Exception {
@@ -442,6 +415,16 @@ public class InstructorsLogicTest extends BaseLogicTest {
         ______TS("failure: instructor doesn't exist");
 
         instructorId = "nonExistingInstructor";
+        
+        for (int i = 0; i < 2; i++) {
+            
+            try {
+                instructorsLogic.verifyInstructorExists(instructorId);
+                signalFailureToDetectException();
+            } catch (EntityDoesNotExistException e) {
+                AssertHelper.assertContains("Instructor does not exist", e.getMessage());
+            }
+        }
 
         try {
             instructorsLogic.verifyInstructorExists(instructorId);
@@ -464,34 +447,32 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("success: instructor belongs to course");
 
-        String instructorEmail = "instructor1@course1.tmt";
-        String courseId = "idOfTypicalCourse1";
-        instructorsLogic.verifyIsEmailOfInstructorOfCourse(instructorEmail, courseId);
+        String[] instructorEmail = {null, "instructor1@course1.tmt"};
+        String[] courseId = {"idOfTypicalCourse1", null};
+        
+        instructorsLogic.verifyIsEmailOfInstructorOfCourse(instructorEmail[1], courseId[0]);
 
         ______TS("failure: instructor doesn't belong to course");
-        instructorEmail = "nonExistingInstructor@email.tmt";
-
+        instructorEmail[1] = "nonExistingInstructor@email.tmt";
+        
+        
         try {
-            instructorsLogic.verifyIsEmailOfInstructorOfCourse(instructorEmail, courseId);
+            instructorsLogic.verifyIsEmailOfInstructorOfCourse(instructorEmail[1], courseId[0]);
             signalFailureToDetectException();
         } catch (EntityDoesNotExistException e) {
-            assertEquals("Instructor " + instructorEmail
-                    + " does not belong to course " + courseId, e.getMessage());
+            assertEquals("Instructor " + instructorEmail[1]
+                    + " does not belong to course " + courseId[0], e.getMessage());
         }
         ______TS("failure: null parameter");
-
-        try {
-            instructorsLogic.verifyIsEmailOfInstructorOfCourse(null, courseId);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
-
-        try {
-            instructorsLogic.verifyIsEmailOfInstructorOfCourse(instructorEmail, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+        
+        for (int i = 0; i < 2; i++) {
+            
+            try {
+                instructorsLogic.verifyIsEmailOfInstructorOfCourse(instructorEmail[i], courseId[i]);
+                signalFailureToDetectException();
+            } catch (AssertionError e) {
+                AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+            }
         }
     }
 
@@ -635,33 +616,29 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("typical case: delete an instructor for specific course");
 
-        String courseId = "idOfTypicalCourse1";
-        String email = "instructor3@course1.tmt";
+        String[] courseId = {"idOfTypicalCourse1", null};
+        String[] email = {null, "instructor3@course1.tmt", "non-existent@course1.tmt"};
+        
+        InstructorAttributes instructorDeleted = instructorsLogic.getInstructorForEmail(courseId[0], email[1]);
 
-        InstructorAttributes instructorDeleted = instructorsLogic.getInstructorForEmail(courseId, email);
-
-        instructorsLogic.deleteInstructorCascade(courseId, email);
+        instructorsLogic.deleteInstructorCascade(courseId[0], email[1]);
 
         verifyAbsentInDatastore(instructorDeleted);
 
         ______TS("typical case: delete a non-existent instructor");
 
-        instructorsLogic.deleteInstructorCascade(courseId, "non-existent@course1.tmt");
+        instructorsLogic.deleteInstructorCascade(courseId[0], email[2]);
 
         ______TS("failure: null parameter");
-
-        try {
-            instructorsLogic.deleteInstructorCascade(courseId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
-
-        try {
-            instructorsLogic.deleteInstructorCascade(null, email);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+        
+        for (int i = 0; i < 2; i++) {
+            
+            try {
+                instructorsLogic.deleteInstructorCascade(courseId[i], email[i]);
+                signalFailureToDetectException();
+            } catch (AssertionError e) {
+                AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+            }
         }
 
         // restore deleted instructor


### PR DESCRIPTION
Fixes #8162

Upon reviewing the logic test suite, I noticed that some test cases perform excess try-catch blocks to test null parameters. For try-catch blocks that test null parameters, I refactored the test to place the try-catch block within a loop and pass in an array to improve code quality and code coverage percentages. 
